### PR TITLE
Concat typesafe configuration files.

### DIFF
--- a/uniform-assembly/src/main/scala/au/com/cba/omnia/uniform/assembly/UniformAssemblyPlugin.scala
+++ b/uniform-assembly/src/main/scala/au/com/cba/omnia/uniform/assembly/UniformAssemblyPlugin.scala
@@ -35,6 +35,8 @@ object UniformAssemblyPlugin extends Plugin {
     case "META-INF/NOTICE.txt" => MergeStrategy.rename
     case "META-INF/LICENSE.txt" => MergeStrategy.rename
     case "META-INF/MANIFEST.MF" => MergeStrategy.discard
+    case "application.conf" => MergeStrategy.concat
+    case "reference.conf"   => MergeStrategy.concat
     case PathList("META-INF", xs) if xs.toLowerCase.endsWith(".dsa") => MergeStrategy.discard
     case PathList("META-INF", xs) if xs.toLowerCase.endsWith(".rsa") => MergeStrategy.discard
     case PathList("META-INF", xs) if xs.toLowerCase.endsWith(".sf") => MergeStrategy.discard


### PR DESCRIPTION
This is required for libraries that make use of typesafe configuration files (HOCON format). Putting it in uniform so you don't have to override it in every build file that uses this.