### PR TITLE
allow projects to change jvm version of compiled artifacts

### DIFF
--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/Scala.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/Scala.scala
@@ -17,4 +17,5 @@ package au.com.cba.omnia.uniform.core.scala
 object Scala {
   val version       = "2.11.6"
   val binaryVersion = version.substring(0, version.lastIndexOf('.'))
+  val jvmVersion    = "1.7"
 }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/setting/ScalaSettings.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/setting/ScalaSettings.scala
@@ -21,11 +21,18 @@ import Keys._
 import au.com.cba.omnia.uniform.core.scala.Scala
 
 object ScalaSettings extends Plugin {
+  lazy val uniformJvmTarget = SettingKey[String](
+    "uniform-jvm-target",
+    "The JVM version targetted by scala and java compilers"
+  )
+
   object scala {
+
     def settings = Seq(
-      scalaVersion := Scala.version,
+      scalaVersion       := Scala.version,
       crossScalaVersions := Seq(Scala.version),
-      scalacOptions ++= Seq(
+      uniformJvmTarget   := Scala.jvmVersion,
+      scalacOptions <++= uniformJvmTarget.map(jvmTarget => Seq(
         "-deprecation",
         "-unchecked",
         "-Xlint",
@@ -34,13 +41,13 @@ object ScalaSettings extends Plugin {
         "-Ywarn-unused-import",
         "-feature",
         "-language:_",
-        "-target:jvm-1.7"
-      ),
-      javacOptions ++= Seq(
+        s"-target:jvm-$jvmTarget"
+      )),
+      javacOptions <++= uniformJvmTarget.map(jvmTarget => Seq(
         "-Xlint:unchecked",
-        "-source", "1.7",
-        "-target", "1.7"
-      )
+        "-source", Scala.jvmVersion,
+        "-target", jvmTarget
+      ))
     )
   }
 }

--- a/uniform-thrift/src/main/scala/au/com/cba/omnia/uniform/thrift/UniformThriftPlugin.scala
+++ b/uniform-thrift/src/main/scala/au/com/cba/omnia/uniform/thrift/UniformThriftPlugin.scala
@@ -14,28 +14,14 @@
 
 package au.com.cba.omnia.uniform.thrift
 
+import au.com.cba.omnia.uniform.dependency.UniformDependencyPlugin._
+import com.twitter.scrooge.ScroogeSBT._
 import sbt._, Keys._
 
-import com.twitter.scrooge.ScroogeSBT._
-
-import au.com.cba.omnia.uniform.core.scala.Scala
-
-import au.com.cba.omnia.uniform.dependency.UniformDependencyPlugin._
-
 object UniformThriftPlugin extends Plugin {
-
-  lazy val uniformThriftJvmTarget = SettingKey[String](
-    "uniform-thrift-jvm-target",
-    "The JVM version targetted by the scrooge thrift plugin"
+  def uniformThriftSettings: Seq[Sett] = newSettings ++ Seq[Sett](
+    libraryDependencies ++= depend.scrooge(),
+    // Force scrooge-gen to always be run (it is buggy w.r.t. picking up changes to new thrift files).
+    (scroogeIsDirty in Compile) <<= (scroogeIsDirty in Compile) map { (_) => true }
   )
-
-  def uniformThriftSettings: Seq[Sett] =
-    newSettings ++
-    Seq[Sett](
-      uniformThriftJvmTarget := Scala.jvmVersion,
-      scroogeBuildOptions in Compile <+= uniformThriftJvmTarget.apply(jvmTarget => s"-target:jvm-$jvmTarget"),
-      libraryDependencies ++= depend.scrooge(),
-      // Force scrooge-gen to always be run (it is buggy w.r.t. picking up changes to new thrift files).
-      (scroogeIsDirty in Compile) <<= (scroogeIsDirty in Compile) map { (_) => true }
-    )
 }

--- a/uniform-thrift/src/main/scala/au/com/cba/omnia/uniform/thrift/UniformThriftPlugin.scala
+++ b/uniform-thrift/src/main/scala/au/com/cba/omnia/uniform/thrift/UniformThriftPlugin.scala
@@ -14,14 +14,28 @@
 
 package au.com.cba.omnia.uniform.thrift
 
-import au.com.cba.omnia.uniform.dependency.UniformDependencyPlugin._
-import com.twitter.scrooge.ScroogeSBT._
 import sbt._, Keys._
 
+import com.twitter.scrooge.ScroogeSBT._
+
+import au.com.cba.omnia.uniform.core.scala.Scala
+
+import au.com.cba.omnia.uniform.dependency.UniformDependencyPlugin._
+
 object UniformThriftPlugin extends Plugin {
-  def uniformThriftSettings: Seq[Sett] = newSettings ++ Seq[Sett](
-    libraryDependencies ++= depend.scrooge(),
-    // Force scrooge-gen to always be run (it is buggy w.r.t. picking up changes to new thrift files).
-    (scroogeIsDirty in Compile) <<= (scroogeIsDirty in Compile) map { (_) => true }
+
+  lazy val uniformThriftJvmTarget = SettingKey[String](
+    "uniform-thrift-jvm-target",
+    "The JVM version targetted by the scrooge thrift plugin"
   )
+
+  def uniformThriftSettings: Seq[Sett] =
+    newSettings ++
+    Seq[Sett](
+      uniformThriftJvmTarget := Scala.jvmVersion,
+      scroogeBuildOptions in Compile <+= uniformThriftJvmTarget.apply(jvmTarget => s"-target:jvm-$jvmTarget"),
+      libraryDependencies ++= depend.scrooge(),
+      // Force scrooge-gen to always be run (it is buggy w.r.t. picking up changes to new thrift files).
+      (scroogeIsDirty in Compile) <<= (scroogeIsDirty in Compile) map { (_) => true }
+    )
 }


### PR DESCRIPTION
Bureaucracy needs to run one of it's artifacts (oracle plugin) on jdk 6.