### PR TITLE
Change scrooge thrift output folders to work around Scrooge bug.

### DIFF
--- a/uniform-thrift/src/main/scala/au/com/cba/omnia/uniform/thrift/UniformThriftPlugin.scala
+++ b/uniform-thrift/src/main/scala/au/com/cba/omnia/uniform/thrift/UniformThriftPlugin.scala
@@ -21,6 +21,9 @@ import sbt._, Keys._
 object UniformThriftPlugin extends Plugin {
   def uniformThriftSettings: Seq[Sett] = newSettings ++ Seq[Sett](
     libraryDependencies ++= depend.scrooge(),
+    // Work around https://github.com/twitter/scrooge/issues/188
+    (scroogeThriftOutputFolder in Compile) <<= (sourceManaged in Compile) (_ / "scrooge"),
+    (scroogeThriftOutputFolder in Test) <<= (sourceManaged in Test) (_ / "scrooge"),
     // Force scrooge-gen to always be run (it is buggy w.r.t. picking up changes to new thrift files).
     (scroogeIsDirty in Compile) <<= (scroogeIsDirty in Compile) map { (_) => true }
   )

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.2.2"
+version in ThisBuild := "1.2.3"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
For Scala 2.11 https://github.com/twitter/scrooge/issues/188 breaks
compilation. Until we have a version of scrooge that fixes this we can
avoid the problem by writting the scrooge generated files to their own folder.