### PR TITLE
Allow configuration to be specified when calling depend.omnia(..)

### DIFF
--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
@@ -213,8 +213,8 @@ object UniformDependencyPlugin extends Plugin {
       def objenesis     = "1.2"
     }
 
-    def omnia(project: String, version: String): Seq[ModuleID] =
-      Seq("au.com.cba.omnia" %% project % version)
+    def omnia(project: String, version: String, configuration: String = "compile"): Seq[ModuleID] =
+      Seq("au.com.cba.omnia" %% project % version % configuration)
 
     def scaldingproject(
       hadoop: String     = versions.hadoop,

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.2.3"
+version in ThisBuild := "1.2.4"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
It is now possible to specify the configuration (e.g. test) when using `depend.omnia(..)`

For example:
```
depend.omnia("permafrost", permafrostVersion) ++
depend.omnia("omnia-test", omniaTestVersion, "test") ++
```