### PR TITLE
Fixes broken source code links.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.2.6"
+version in ThisBuild := "1.2.7"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
The changes in `64ea86c` caused the links in Scaladocs to the Github
source code to no longer be correct.