### PR TITLE
Suppress unused import warnings from sbt console

### DIFF
--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/setting/ScalaSettings.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/setting/ScalaSettings.scala
@@ -36,6 +36,8 @@ object ScalaSettings extends Plugin {
         "-language:_",
         "-target:jvm-1.7"
       ),
+      scalacOptions in (Compile, console) ~= (_.filterNot(Set("-Ywarn-unused-import"))),
+      scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
       javacOptions ++= Seq(
         "-Xlint:unchecked",
         "-source", "1.7",

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.4.0"
+version in ThisBuild := "1.4.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Partially addresses #61 

As @SamRoberts mentioned in that issue, the implementation of setting options globally then filtering doesn't seem ideal. Another option would be to omit the global setting then add it to the `Compile` and `Test` configurations
```scala
Seq(Compile, Test).map(scalacOptions in (_, compile) += "-Ywarn-unused-import")
```
but this seems more prone to missing other, potentially custom, configurations that may be applicable (or am I overthinking it?).

Explicitly specifying the `Compile` and `Test` configurations to the `in` method appears to be required, regardless of whether filtering or appending. Using the `Default` configuration, or omitting it altogether and only providing the `compile` task scope doesn't produce the desired behaviour based on local testing. If someone with more knowledge of sbt's scope axes has any other suggestions, chime in here.