### PR TITLE
minor refactoring to GitStatus etc

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -92,7 +92,7 @@ object build extends Build {
     unidocSettings ++ site.settings ++ Seq(
       site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "latest/api"),
       includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.yml",
-      apiURL <<= (baseDirectory).apply(base => Some(url(s"https://commbank.github.io/${base.getName}/latest/api"))),
+      apiURL <<= baseDirectory(base => Some(url(s"https://commbank.github.io/${ base.getName }/latest/api"))),
       scalacOptions in (ScalaUnidoc, unidoc) <++= (version, baseDirectory).map { (v, base) =>
         val docSourceUrl = s"https://github.com/CommBank/uniform/blob/master/€{FILE_PATH}.scala"
         Seq("-sourcepath", base.getAbsolutePath, "-doc-source-url", docSourceUrl)

--- a/project/version.scala
+++ b/project/version.scala
@@ -20,7 +20,7 @@ import sbt._, Keys._
 
 object UniqueVersion extends Plugin {
   def uniqueVersionSettings = Seq(
-    version in ThisBuild        <<=  (version in ThisBuild, baseDirectory).apply((v, d)=> v + "-" + timestamp(now) + "-" + commish(d))
+    version in ThisBuild <<= (version in ThisBuild, baseDirectory) ((v, d) => v + "-" + timestamp(now) + "-" + commish(d))
   )
 
   def timestamp(instant: Date, format: String = "yyyyMMddHHmmss") = {

--- a/uniform-assembly/src/main/scala/au/com/cba/omnia/uniform/assembly/UniformAssemblyPlugin.scala
+++ b/uniform-assembly/src/main/scala/au/com/cba/omnia/uniform/assembly/UniformAssemblyPlugin.scala
@@ -23,9 +23,9 @@ object UniformAssemblyPlugin extends Plugin {
     baseAssemblySettings ++ Seq[Sett](
       assemblyMergeStrategy in assembly <<= (assemblyMergeStrategy in assembly)(defaultMergeStrategy),
       test in assembly := {},
-      (artifact in (Compile, assembly) ~= { art =>
+      artifact in (Compile, assembly) ~= { art =>
         art.copy(`classifier` = Some("assembly"))
-      })
+      }
     ) ++ addArtifact(artifact in (Compile, assembly), assembly)
 
 

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/GitInfo.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/GitInfo.scala
@@ -20,10 +20,16 @@ import _root_.scala.Console.{RED, BOLD, RESET}
 import sbt._, Keys._
 
 sealed abstract class GitStatus {
-  def show() = this match {
+  def show = this match {
     case NotAGitRepository => "UNTRACKED"
     case Dirty(hash)       => hash + "-SNAPSHOT"
-    case Clean(hash)       => hash 
+    case Clean(hash)       => hash
+  }
+
+  def hashOption: Option[String] = this match {
+    case NotAGitRepository => None
+    case Clean(hash)       => Some(hash)
+    case Dirty(hash)       => Some(hash)
   }
 }
 
@@ -33,36 +39,34 @@ case class Clean(hash: String) extends GitStatus
 
 case class Dirty(hash: String) extends GitStatus
 
+object GitStatus {
+  def apply(root: File, format: String): GitStatus =
+    if (!isGitRepository(root)) NotAGitRepository
+    else {
+      val lastCommit = Process(s"git log --pretty=format:$format -n 1", cwd = Some(root)).lines.head
+      if (isGitRepositoryClean(root))
+        Clean(lastCommit)
+      else
+        Dirty(lastCommit)
+    }
+
+  private def isGitRepository(root: File): Boolean =
+    Process("git status", cwd = Some(root)) ! OnlyLogStdErr == 0
+
+  private def isGitRepositoryClean(root: File): Boolean =
+    Process("git status --porcelain", cwd = Some(root)).lines.isEmpty
+}
+
 /** Logs any STDERR output in bold red and discards STDOUT output */
 object OnlyLogStdErr extends ProcessLogger {
-  override def buffer[T](f: => T)  = f
-  override def error(s: => String) = println(s"${RED}${BOLD}${s}${RESET}")
-  override def info(s: => String)  = {}
+  override def buffer[T](f: => T) = f
+  override def error(s: => String) = println(s"$RED$BOLD$s$RESET")
+  override def info(s: => String) = {}
 }
 
 object GitInfo {
-  def commish(root: File): GitStatus =
-    gitlog(root, "%h")
+  def commish(root: File): GitStatus = GitStatus(root, "%h")
 
-  def commit(root: File): GitStatus =
-    gitlog(root, "%H")
+  def commit(root: File): GitStatus = GitStatus(root, "%H")
 
-  def gitlog(root: File, format: String): GitStatus = {
-    if (isGitRepository(root)) {
-      val lastCommit = Process("git log --pretty=format:" + format + " -n  1", Some(root)).lines.head
-      if (isGitRepositoryDirty(root)) {
-        Dirty(lastCommit)
-      } else {
-        Clean(lastCommit)
-      }
-    } else {
-      NotAGitRepository
-    }
-  }
-
-  def isGitRepository(root: File): Boolean =
-    Process("git status", Some(root)).!(OnlyLogStdErr) == 0
-
-  def isGitRepositoryDirty(root: File): Boolean =
-    Process("git status --porcelain", Some(root)).lines.nonEmpty
 }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/Times.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/Times.scala
@@ -17,16 +17,16 @@ package version
 
 import java.text.SimpleDateFormat
 import java.util.{Date, TimeZone}
-
 import sbt._, Keys._
 
 object Times {
-  def timestamp(instant: Date, format: String = "yyyyMMddHHmmss") = {
-    val formatter = new SimpleDateFormat("yyyyMMddHHmmss")
-    formatter.setTimeZone(TimeZone.getTimeZone("UTC"))
-    formatter.format(instant)
+  lazy val formatter = {
+    val f = new SimpleDateFormat("yyyyMMddHHmmss")
+    f.setTimeZone(TimeZone.getTimeZone("UTC"))
+    f
   }
 
-  lazy val now =
-    new Date
+  def timestamp(instant: Date) = formatter.format(instant)
+
+  lazy val now = new Date
 }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/UniqueVersionPlugin.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/UniqueVersionPlugin.scala
@@ -18,10 +18,11 @@ package version
 import sbt._, Keys._
 
 object UniqueVersionPlugin extends Plugin {
+
   import Times._
   import GitInfo._
-  
+
   def uniqueVersionSettings = Seq(
-    version in ThisBuild        <<=  (version in ThisBuild, baseDirectory).apply((v, d)=> v + "-" + timestamp(now) + "-" + commish(d).show())
+    version in ThisBuild <<= (version in ThisBuild, baseDirectory) { (v, d) => v + "-" + timestamp(now) + "-" + commish(d).show }
   )
 }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/VersionInfoPlugin.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/VersionInfoPlugin.scala
@@ -17,9 +17,6 @@ package version
 
 import sbt._, Keys._
 
-import java.util.Date
-import java.text.SimpleDateFormat
-
 object VersionInfoPlugin extends Plugin {
   import Times._
   import GitInfo._

--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
@@ -257,11 +257,11 @@ object UniformDependencyPlugin extends Plugin {
 
     def hadoop(version: String = versions.hadoop) = Seq(
       "org.apache.hadoop"        % "hadoop-client"                  % version
-    ) map (noHadoop(_))
+    ) map noHadoop
 
     def hive(version: String = versions.hive) = Seq(
       "org.apache.hive"          % "hive-exec"                      % version
-    ) map (noHadoop(_))
+    ) map noHadoop
 
     def scalaz(version: String = versions.scalaz) = Seq(
       "org.scalaz"               %% "scalaz-core"                   % version,
@@ -313,10 +313,10 @@ object UniformDependencyPlugin extends Plugin {
     def scrooge(scrooge: String = versions.scrooge, bijection: String = versions.bijection) = Seq(
       "com.twitter"              %% "scrooge-core"                  % scrooge,
       "com.twitter"              %% "bijection-scrooge"             % bijection exclude("com.twitter", sv("scrooge-core"))
-    ) map (noHadoop(_))
+    ) map noHadoop
 
     def parquet(version: String = versions.parquet) = Seq(
       "com.twitter"              % "parquet-cascading"              % version     % "provided"
-    ) map (noHadoop(_))
+    ) map noHadoop
   }
 }


### PR DESCRIPTION
Some minor refactorings:

* rename `gitlog` method on `GitInfo` to `apply`, and put logic to get optional git hash inside `GitInfo`
* reuse `SimpleDateFormat` in `Times`
* remove redundant imports and `apply`s
