### PR TITLE
Update Scala 2.10 and 2.11 versions to latest

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -26,7 +26,7 @@ object build extends Build {
     Defaults.coreDefaultSettings ++ Seq[Sett](
       organization := "au.com.cba.omnia"
     , sbtPlugin := true
-    , scalaVersion := "2.10.5"
+    , scalaVersion := "2.10.6"
     , scalacOptions := Seq(
         "-deprecation"
       , "-unchecked"

--- a/project/version.scala
+++ b/project/version.scala
@@ -24,20 +24,17 @@ object UniqueVersion extends Plugin {
   )
 
   def timestamp(instant: Date, format: String = "yyyyMMddHHmmss") = {
-    val formatter = new SimpleDateFormat("yyyyMMddHHmmss")
+    val formatter = new SimpleDateFormat(format)
     formatter.setTimeZone(TimeZone.getTimeZone("UTC"))
     formatter.format(instant)
   }
 
-  def commish(root: File) =
-    gitlog(root, "%h")
+  def commish(root: File) = gitlog(root, "%h")
 
-  def commit(root: File) =
-    gitlog(root, "%H")
+  def commit(root: File) = gitlog(root, "%H")
 
   def gitlog(root: File, format: String) =
     Process("git log --pretty=format:" + format + " -n  1", Some(root)).lines.head
 
-  lazy val now =
-    new Date
+  lazy val now = new Date
 }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/Scala.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/Scala.scala
@@ -15,6 +15,6 @@
 package au.com.cba.omnia.uniform.core.scala
 
 object Scala {
-  val version       = "2.11.6"
+  val version       = "2.11.7"
   val binaryVersion = version.substring(0, version.lastIndexOf('.'))
 }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/standard/StandardProjectPlugin.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/standard/StandardProjectPlugin.scala
@@ -77,7 +77,7 @@ object StandardProjectPlugin extends Plugin {
 
     /** Adds settings for crossbuilding against Scala 2.10. */
     def crossBuild = Seq(
-      crossScalaVersions := Seq(scalaVersion.value, "2.10.5"),
+      crossScalaVersions := Seq(scalaVersion.value, "2.10.6"),
       scalacOptions      := scalacOptions.value.filter(o =>
         !(scalaBinaryVersion.value == "2.10" && o == "-Ywarn-unused-import")
       )

--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
@@ -212,6 +212,7 @@ object UniformDependencyPlugin extends Plugin {
       def libthrift     = "0.9.0-cdh5-3"
 
       // non-hadoop modules
+      def macroParadise = "2.1.0"
       def specs         = "3.5"
       def scalaz        = "7.1.1"  // Needs to align with what is required by specs2
       def scalazStream  = "0.7a"   // Needs to align with what is required by specs2
@@ -262,6 +263,10 @@ object UniformDependencyPlugin extends Plugin {
     def hive(version: String = versions.hive) = Seq(
       "org.apache.hive"          % "hive-exec"                      % version
     ) map noHadoop
+
+    /** Not a `Seq` since it's a compiler plugin, not a dependency */
+    def macroParadise(version: String = versions.macroParadise) =
+      "org.scalamacros"          % "paradise"                       % versions.macroParadise cross CrossVersion.full
 
     def scalaz(version: String = versions.scalaz) = Seq(
       "org.scalaz"               %% "scalaz-core"                   % version,

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.4.1"
+version in ThisBuild := "1.5.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This PR udpates to the latest 2.10 and 2.11 patch releases.

Release notes:
http://www.scala-lang.org/news/2.10.6
http://www.scala-lang.org/news/2.11.7