### PR TITLE
bump nscala to 2.10.0 and joda to 2.9.2

### DIFF
--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
@@ -222,8 +222,8 @@ object UniformDependencyPlugin extends Plugin {
       def scalazStream  = "0.7a"   // Needs to align with what is required by specs2
       def shapeless     = "2.2.5"
       def scalacheck    = "1.11.4" // Downgrade to a version that works with both specs2 and scalaz
-      def nscalaTime    = "1.8.0"
-      def jodaTime      = "2.7"    // Needs to align with what is required by nscala-time
+      def nscalaTime    = "2.10.0"
+      def jodaTime      = "2.9.2"    // Needs to align with what is required by nscala-time
       def scalding      = "0.13.1"
       def cascading     = "2.6.1"  // Needs to align with what is required by scalding
       def algebird      = "0.9.0"  // Needs to align with what is required by scalding

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.7.0"
+version in ThisBuild := "1.8.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
nscala-time resolves most of our needs (especially in data products) in terms of date time operations. However, the old versions were missing some of the functionalities that we often use. Recently, I have updated nscala-time meet some of these requirements, and I wanted this to be available across the projects and hence this PR.

https://github.com/nscala-time/nscala-time/pull/99
https://github.com/nscala-time/nscala-time/issues/100

It seems we have unusually complex codes (in data products stash repositories) to handle date-time operations regardless of the simplicity in the use-cases it tries to solve. This PR is the first step forward..