### PR TITLE
Exposed netty version as a constant

### DIFF
--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
@@ -166,7 +166,7 @@ object UniformDependencyPlugin extends Plugin {
       "com.sun.jersey.contribs"      % "jersey-guice"              % "1.9",
       "org.fusesource.leveldbjni"    % "leveldbjni-all"            % "1.8",
       "asm"                          % "asm"                       % depend.versions.asm,
-      "io.netty"                     % "netty"                     % "3.6.2.Final"
+      "io.netty"                     % "netty"                     % depend.versions.netty
     )
 
     // Different versions of these jars have different organizations. Could do
@@ -210,6 +210,7 @@ object UniformDependencyPlugin extends Plugin {
       def asm           = "3.2"
       def guava         = "11.0.2"
       def jackson       = "1.8.8"
+      def netty         = "3.6.2.Final"
 
       // cloudera modules *not* on the hadoop classpath
       def hive          = "0.13.1-cdh5.3.8"

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.8.0"
+version in ThisBuild := "1.8.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
The Houston client will need to use the same version of netty as that which is on the hadoop CP, so this change exposes it.