### PR TITLE
Version setting to append `-SNAPSHOT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ it should look like this:
 ```
 version in ThisBuild := "0.0.1"
 
-uniqueVersionSettings
+localVersionSettings
 ```
 
-This will generate a unique build, consisiting of `${version}-${timestamp}-${commish}`.
+This will append `-SNAPSHOT` to the version number. The CI builds overwrite the version with a unique version at build time.
 
 
 `uniform` flavours provide additional pre-canned configs for `assembly`, `thrift` and consistent dependency versions.

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/LocalVersionPlugin.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/LocalVersionPlugin.scala
@@ -12,8 +12,14 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.9.0"
+package au.com.cba.omnia.uniform.core
+package version
 
-uniqueVersionSettings
+import sbt._, Keys._
 
-licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+object LocalVersionPlugin extends Plugin {
+  /** Appends `-SNAPSHOT` to the version. */
+  def localVersionSettings = Seq(
+    version in ThisBuild <<= (version in ThisBuild)(v => s"$v-SNAPSHOT")
+  )
+}

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/UniqueVersionPlugin.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/UniqueVersionPlugin.scala
@@ -23,6 +23,7 @@ object UniqueVersionPlugin extends Plugin {
   import GitInfo._
 
   /** Appends the timestamp and commish to the specified version number. */
+  @deprecated("This will be removed in future versions since we use the CI to set the version number. Please use `localVersionSettings` instead.","1.9.0")
   def uniqueVersionSettings = Seq(
     version in ThisBuild <<= (version in ThisBuild, baseDirectory) { (v, d) => v + "-" + timestamp(now) + "-" + commish(d).show }
   )

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/UniqueVersionPlugin.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/version/UniqueVersionPlugin.scala
@@ -22,6 +22,7 @@ object UniqueVersionPlugin extends Plugin {
   import Times._
   import GitInfo._
 
+  /** Appends the timestamp and commish to the specified version number. */
   def uniqueVersionSettings = Seq(
     version in ThisBuild <<= (version in ThisBuild, baseDirectory) { (v, d) => v + "-" + timestamp(now) + "-" + commish(d).show }
   )


### PR DESCRIPTION
This addresses the comment in #76 of appending `-SNAPSHOT` to our local builds.

Going forward this should replace `uniqueVersionSettings` since our CI tooling actually handles the creating of the version numbers.