### PR TITLE
upgrade scala version to 2.11.8, and allow jvm version to be configured

### DIFF
--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/Scala.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/Scala.scala
@@ -15,6 +15,7 @@
 package au.com.cba.omnia.uniform.core.scala
 
 object Scala {
-  val version       = "2.11.7"
+  val version       = "2.11.8"
   val binaryVersion = version.substring(0, version.lastIndexOf('.'))
+  val jvmVersion    = "1.7"
 }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/setting/ScalaSettings.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/setting/ScalaSettings.scala
@@ -22,7 +22,7 @@ import au.com.cba.omnia.uniform.core.scala.Scala
 
 object ScalaSettings extends Plugin {
   object scala {
-    def settings = Seq(
+    def settings(jvmVersion: String = Scala.jvmVersion) = Seq(
       scalaVersion := Scala.version,
       crossScalaVersions := Seq(Scala.version),
       scalacOptions ++= Seq(
@@ -34,14 +34,14 @@ object ScalaSettings extends Plugin {
         "-Ywarn-unused-import",
         "-feature",
         "-language:_",
-        "-target:jvm-1.7"
+        s"-target:jvm-${jvmVersion}"
       ),
       scalacOptions in (Compile, console) ~= (_.filterNot(Set("-Ywarn-unused-import"))),
       scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
       javacOptions ++= Seq(
         "-Xlint:unchecked",
-        "-source", "1.7",
-        "-target", "1.7"
+        "-source", jvmVersion,
+        "-target", jvmVersion
       )
     )
   }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/standard/StandardProjectPlugin.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/standard/StandardProjectPlugin.scala
@@ -21,6 +21,7 @@ import sbtunidoc.Plugin._, UnidocKeys._
 
 import com.typesafe.sbt.SbtSite._, SiteKeys._
 
+import au.com.cba.omnia.uniform.core.scala.Scala
 import au.com.cba.omnia.uniform.core.setting.ScalaSettings.scala
 import au.com.cba.omnia.uniform.core.version.GitInfo
 import au.com.cba.omnia.uniform.core.version.VersionInfoPlugin.{versionInfoSettings, rootPackage}
@@ -45,11 +46,11 @@ object StandardProjectPlugin extends Plugin {
     lazy val docRootUrl = SettingKey[String]("doc-root-url", "Github Pages root URL (e.g. https://commbank.github.io)")
     lazy val docSourceUrl = SettingKey[String]("doc-source-url", "Github or Github Enterprise root URL (e.g. https://github.com/CommBank")
 
-    def project(project: String, pkg: String, org: String = "omnia") = List(
+    def project(project: String, pkg: String, org: String = "omnia", jvmVersion: String = Scala.jvmVersion) = List(
       name := project,
       organization := s"au.com.cba.$org",
       rootPackage := pkg
-    ) ++ scala.settings ++ versionInfoSettings
+    ) ++ scala.settings(jvmVersion = jvmVersion) ++ versionInfoSettings
 
     /** Settings for each sbt project and subproject to create api mappings and expose api url.*/
     def docSettings(link: String): Seq[sbt.Setting[_]] = Seq(

--- a/uniform-dependency/src/sbt-test/dependencies/all/build.sbt
+++ b/uniform-dependency/src/sbt-test/dependencies/all/build.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-scala.settings
+scala.settings()
 
 uniformDependencySettings
 

--- a/uniform-dependency/src/sbt-test/dependencies/scalacheck-scalaz/build.sbt
+++ b/uniform-dependency/src/sbt-test/dependencies/scalacheck-scalaz/build.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-scala.settings
+scala.settings()
 
 uniformDependencySettings
 

--- a/uniform-thrift/src/sbt-test/thrift/compat/build.sbt
+++ b/uniform-thrift/src/sbt-test/thrift/compat/build.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-scala.settings
+scala.settings()
 
 uniformDependencySettings
 

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.9.0"
+version in ThisBuild := "1.10.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Hi guys, happy to upgrade to scala 2.11.8?

Allowing the jvm version to be configured does introduce a minor backwards incompatibility: users may have to put empty brackets after a call to scala.settings. I think this had to happen eventually though.