### PR TITLE
Avoid clobbering assembly settings from other plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ An sbt plugin for maintaining uniform approach to building cba components.
 usage
 -----
 
+Supported: sbt 0.13.6 or higher (same as [sbt-assembly](https://github.com/sbt/sbt-assembly#using-published-plugin)).
+
 See https://commbank.github.io/uniform/index.html for the latest version number.
 
 `uniform` helps provide a consistent set of scala settings across projects.

--- a/uniform-assembly/src/main/scala/au/com/cba/omnia/uniform/assembly/UniformAssemblyPlugin.scala
+++ b/uniform-assembly/src/main/scala/au/com/cba/omnia/uniform/assembly/UniformAssemblyPlugin.scala
@@ -19,15 +19,13 @@ import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
 object UniformAssemblyPlugin extends Plugin {
-  def uniformAssemblySettings: Seq[Sett] =
-    baseAssemblySettings ++ Seq[Sett](
+  def uniformAssemblySettings: Seq[Sett] = Seq(
       assemblyMergeStrategy in assembly <<= (assemblyMergeStrategy in assembly)(defaultMergeStrategy),
       test in assembly := {},
       artifact in (Compile, assembly) ~= { art =>
         art.copy(`classifier` = Some("assembly"))
       }
     ) ++ addArtifact(artifact in (Compile, assembly), assembly)
-
 
   def defaultMergeStrategy(old: String => MergeStrategy) =  (path: String) => path match {
     case "META-INF/LICENSE" => MergeStrategy.rename
@@ -42,5 +40,4 @@ object UniformAssemblyPlugin extends Plugin {
     case PathList("META-INF", xs) if xs.toLowerCase.endsWith(".sf") => MergeStrategy.discard
     case _ => MergeStrategy.first
   }
-
 }

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.11.0"
+version in ThisBuild := "1.11.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
I encountered this issue when trying to write an SBT auto plugin which adds sbt-assembly settings. Looks like a hang-over from the days before sbt-assembly was made an auto plugin.

Since sbt-assembly is now an auto plugin, the baseAssemblySettings will already have been appended to the project. Appending them again in uniformAssemblySettings is unnecessary, and will clobber changes made by other plugins which add functionality on top of on sbt-assembly.