### PR TITLE
CI: Fix for sbt make-site

### DIFF
--- a/.ci/sbt-ci-build-doc-simple.sh
+++ b/.ci/sbt-ci-build-doc-simple.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -x
+#   Copyright 2016 Commonwealth Bank of Australia
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#   Generate docs with `sbt make-site` then commit to the gh-pages branch.
+
+set -u
+
+# Library import helper
+function import() {
+    IMPORT_PATH="${BASH_SOURCE%/*}"
+    if [[ ! -d "$IMPORT_PATH" ]]; then IMPORT_PATH="$PWD"; fi
+    . $IMPORT_PATH/$1
+    [ $? != 0 ] && echo "$1 import error" 1>&2 && exit 1
+}
+
+import lib-ci
+
+CI_Env_Adapt $(CI_Env_Get)
+
+SBT=$(which_sbt) || exit 1
+
+# Builds documentation.
+function do_build_doc() {
+    mkdir -p target/site
+
+    echo "Creating documentation..."
+    $SBT -Dsbt.global.base=$CI_BUILD_DIR \
+        make-site
+    if [ $? != 0 ]; then
+        echoerr "Error building documentation"
+        exit 1
+    fi
+}
+
+do_build_doc
+
+# Should documentation be published?
+if [ $CI_BRANCH = "master" ] || [ ! -z $FORCE_PUBLISH ]; then
+    Publish_Subdirectory_To_Branch gh-pages target/site "CI automatic documentation ($CI_BUILD_URL)"
+else
+    echoerr "This is not the master branch so documentation is not being published."
+fi
+
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ cache:
   - $HOME/.m2
 install:
 - curl https://commbank.artifactoryonline.com/commbank/binaries/ci/ci-$CI_VERSION.tar.gz | tar xz
+- cp .ci/sbt-ci-build-doc-simple.sh ci/
 - ci/sbt-ci-setup.sh
 - ci/sbt-ci-setup-version.sh
 - cp /etc/sbt/sbtopts .sbtopts; echo "-Dsbt.global.base=$TRAVIS_BUILD_DIR/ci" >> .sbtopts
 script:
 - sbt test package scripted
   && ci/sbt-ci-deploy.sh ivy http://commbank.artifactoryonline.com/commbank ext-releases-local-ivy
-  && ci/sbt-ci-build-doc.sh https://commbank.github.io/ https://github.com/CommBank/uniform/
+  && ci/sbt-ci-build-doc-simple.sh
   && ci/ci-push-branch.sh gh-pages
 after_script:
 - rm -rf ci


### PR DESCRIPTION
The uniform build is kaput due to the artifactory credentials issue that arose some weeks back.

I've brought uniform forward to use ci2, however there's an issue in building the docs. ci2 expects the project to be using the uniform plugin, which will be the case for all of our projects except this one of course.

This change adds a uniform-specific script to build the gh-pages site (it is a cut down version of [this](https://github.com/CommBank/ci2/blob/master/src/main/bash/sbt-ci-build-doc.sh)).