### PR TITLE
Bring bijection dependency inline with scalding

### DIFF
--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
@@ -224,12 +224,12 @@ object UniformDependencyPlugin extends Plugin {
       def shapeless     = "2.2.5"
       def scalacheck    = "1.11.4" // Downgrade to a version that works with both specs2 and scalaz
       def nscalaTime    = "2.10.0"
-      def jodaTime      = "2.9.2"    // Needs to align with what is required by nscala-time
+      def jodaTime      = "2.9.2"  // Needs to align with what is required by nscala-time
       def scalding      = "0.16.0"
       def cascading     = "2.6.1"  // Needs to align with what is required by scalding
       def algebird      = "0.12.0" // Needs to align with what is required by scalding
       def scrooge       = "3.17.0" // Needs to align with what is required by scalding
-      def bijection     = "0.7.2-OMNIA1" // Needs to align with what is required by scalding
+      def bijection     = "0.9.1"  // Needs to align with what is required by scalding
       def scallop       = "0.9.5"
       def objenesis     = "1.2"
     }

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.14.2"
+version in ThisBuild := "1.14.3"
 
 version in ThisBuild <<= (version in ThisBuild)(v => s"$v-SNAPSHOT") // We can't use LocalVersionPlugin here.
 


### PR DESCRIPTION
Previous version of `bijection` (0.7.2) is not compatible with current version of `scalding-parquet` (0.16.0). Incompatibility manifests itself at runtime as a `NoSuchMethodError` when using ` com.twitter.scalding.parquet.tuple.TypedParquet`.

Note that in-house packaged version of `bijection` is no longer needed now that `bijection-scrooge` for scala 2.11 is available. Partially reverses work-around introduced in https://github.com/CommBank/uniform/commit/9e42859738e39176c089871e0cadc12629c18238

Also minor non-functional formatting alignment fix.