### PR TITLE
Adds support for Scala 2.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-- oraclejdk7
+- oraclejdk8
 sudo: false
 cache:
   directories:

--- a/uniform-core/scripted.sbt
+++ b/uniform-core/scripted.sbt
@@ -1,0 +1,36 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+ScriptedPlugin.scriptedSettings
+
+
+scriptedLaunchOpts := {
+  scriptedLaunchOpts.value ++
+  Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
+}
+
+scriptedBufferLog := false
+
+scriptedRun <<= {
+  scriptedRun.dependsOn((publishLocal in core))
+}
+
+credentials ++= {
+  val out = credentials.value.map {
+    case c: FileCredentials   => s"""Credentials(new java.io.File("${c.path.getAbsolutePath}"))"""
+    case c: DirectCredentials => s"Credentials(${c.realm}, ${c.host}, ${c.userName}, ${c.passwd})"
+  }.mkString(" credentials ++= Seq(", ",", ")")
+  sbtTestDirectory.value.listFiles.flatMap(_.listFiles).map(f => IO.writeLines(f / "credentials.sbt", Seq(out)))
+  List()
+}

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/Scala.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/Scala.scala
@@ -14,8 +14,14 @@
 
 package au.com.cba.omnia.uniform.core.scala
 
-object Scala {
+object Scala11  {
   val version       = "2.11.8"
   val binaryVersion = version.substring(0, version.lastIndexOf('.'))
   val jvmVersion    = "1.7"
+}
+
+object Scala12 {
+  val version       = "2.12.1"
+  val binaryVersion = version.substring(0, version.lastIndexOf('.'))
+  val jvmVersion    = "1.8"
 }

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/package.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/scala/package.scala
@@ -1,0 +1,12 @@
+package au.com.cba.omnia.uniform.core
+
+package object scala {
+  val Scala = Scala11
+
+  /**
+    * Includes all the Scala binary versions we might deal with.
+    *
+    * In particular, this is used by ModuleIdOps to brute force the exclusion of scala dependencies.
+    */
+  val allBinaryVersions = List("2.10", Scala11.binaryVersion, Scala12.binaryVersion)
+}

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/setting/ScalaSettings.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/setting/ScalaSettings.scala
@@ -18,13 +18,16 @@ package setting
 import sbt._
 import Keys._
 
-import au.com.cba.omnia.uniform.core.scala.Scala
+import au.com.cba.omnia.uniform.core.scala.{Scala11, Scala12}
 
 object ScalaSettings extends Plugin {
   object scala {
-    def settings(jvmVersion: String = Scala.jvmVersion) = Seq(
-      scalaVersion := Scala.version,
-      crossScalaVersions := Seq(Scala.version),
+    def settings(jvmVersion: String = Scala11.jvmVersion) = settings11(jvmVersion)
+
+    /** Scala 2.11 settings. */
+    def settings11(jvmVersion: String = Scala11.jvmVersion) = Seq(
+      scalaVersion := Scala11.version,
+      crossScalaVersions := Seq(Scala11.version),
       scalacOptions ++= Seq(
         "-deprecation",
         "-unchecked",
@@ -32,6 +35,31 @@ object ScalaSettings extends Plugin {
         "-Ywarn-dead-code",
         "-Ywarn-value-discard",
         "-Ywarn-unused-import",
+        "-feature",
+        "-language:_",
+        s"-target:jvm-${jvmVersion}"
+      ),
+      scalacOptions in (Compile, console) ~= (_.filterNot(Set("-Ywarn-unused-import"))),
+      scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
+      javacOptions ++= Seq(
+        "-Xlint:unchecked",
+        "-source", jvmVersion,
+        "-target", jvmVersion
+      )
+    )
+
+    /** Scala 2.12 settings. */
+    def settings12(jvmVersion: String = Scala12.jvmVersion) = Seq(
+      scalaVersion := Scala12.version,
+      crossScalaVersions := Seq(Scala12.version),
+      scalacOptions ++= Seq(
+        "-deprecation",
+        "-unchecked",
+        "-Xlint",
+        "-Ywarn-dead-code",
+        "-Ywarn-value-discard",
+        "-Ywarn-unused-import",
+        "-Ypartial-unification",
         "-feature",
         "-language:_",
         s"-target:jvm-${jvmVersion}"

--- a/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/standard/StandardProjectPlugin.scala
+++ b/uniform-core/src/main/scala/au/com/cba/omnia/uniform/core/standard/StandardProjectPlugin.scala
@@ -21,7 +21,7 @@ import sbtunidoc.Plugin._, UnidocKeys._
 
 import com.typesafe.sbt.SbtSite._, SiteKeys._
 
-import au.com.cba.omnia.uniform.core.scala.Scala
+import au.com.cba.omnia.uniform.core.scala.{Scala11, Scala12}
 import au.com.cba.omnia.uniform.core.setting.ScalaSettings.scala
 import au.com.cba.omnia.uniform.core.version.GitInfo
 import au.com.cba.omnia.uniform.core.version.VersionInfoPlugin.{versionInfoSettings, rootPackage}
@@ -46,11 +46,22 @@ object StandardProjectPlugin extends Plugin {
     lazy val docRootUrl = SettingKey[String]("doc-root-url", "Github Pages root URL (e.g. https://commbank.github.io)")
     lazy val docSourceUrl = SettingKey[String]("doc-source-url", "Github or Github Enterprise root URL (e.g. https://github.com/CommBank")
 
-    def project(project: String, pkg: String, org: String = "omnia", jvmVersion: String = Scala.jvmVersion) = List(
+    def project(project: String, pkg: String, org: String = "omnia", jvmVersion: String = Scala11.jvmVersion) =
+      project11(project, pkg, org, jvmVersion)
+
+    def project11(project: String, pkg: String, org: String = "omnia", jvmVersion: String = Scala11.jvmVersion) = List(
       name := project,
       organization := s"au.com.cba.$org",
       rootPackage := pkg
-    ) ++ scala.settings(jvmVersion = jvmVersion) ++ versionInfoSettings
+    ) ++ scala.settings11(jvmVersion = jvmVersion) ++ versionInfoSettings
+
+
+    def project12(project: String, pkg: String, org: String = "omnia", jvmVersion: String = Scala12.jvmVersion) = List(
+      name := project,
+      organization := s"au.com.cba.$org",
+      rootPackage := pkg
+    ) ++ scala.settings12(jvmVersion = jvmVersion) ++ versionInfoSettings
+
 
     /** Settings for each sbt project and subproject to create api mappings and expose api url.*/
     def docSettings(link: String): Seq[sbt.Setting[_]] = Seq(

--- a/uniform-core/src/sbt-test/scala-settings/scala11/build.sbt
+++ b/uniform-core/src/sbt-test/scala-settings/scala11/build.sbt
@@ -12,8 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.15.0"
+scala.settings11()
 
-version in ThisBuild <<= (version in ThisBuild)(v => s"$v-SNAPSHOT") // We can't use LocalVersionPlugin here.
-
-licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+version := "0.1"

--- a/uniform-core/src/sbt-test/scala-settings/scala11/project/plugins.sbt
+++ b/uniform-core/src/sbt-test/scala-settings/scala11/project/plugins.sbt
@@ -1,0 +1,25 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+resolvers += Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]"))
+
+val uniformVersion = {
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else pluginVersion
+}
+
+addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)

--- a/uniform-core/src/sbt-test/scala-settings/scala11/src/main/scala/Main.scala
+++ b/uniform-core/src/sbt-test/scala-settings/scala11/src/main/scala/Main.scala
@@ -12,8 +12,4 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.15.0"
-
-version in ThisBuild <<= (version in ThisBuild)(v => s"$v-SNAPSHOT") // We can't use LocalVersionPlugin here.
-
-licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+object Main {}

--- a/uniform-core/src/sbt-test/scala-settings/scala11/test
+++ b/uniform-core/src/sbt-test/scala-settings/scala11/test
@@ -1,0 +1,1 @@
+> compile

--- a/uniform-core/src/sbt-test/scala-settings/scala12/build.sbt
+++ b/uniform-core/src/sbt-test/scala-settings/scala12/build.sbt
@@ -12,8 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.15.0"
+scala.settings12()
 
-version in ThisBuild <<= (version in ThisBuild)(v => s"$v-SNAPSHOT") // We can't use LocalVersionPlugin here.
-
-licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+version := "0.1"

--- a/uniform-core/src/sbt-test/scala-settings/scala12/project/plugins.sbt
+++ b/uniform-core/src/sbt-test/scala-settings/scala12/project/plugins.sbt
@@ -1,0 +1,25 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+resolvers += Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]"))
+
+val uniformVersion = {
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else pluginVersion
+}
+
+addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)

--- a/uniform-core/src/sbt-test/scala-settings/scala12/src/main/scala/Main.scala
+++ b/uniform-core/src/sbt-test/scala-settings/scala12/src/main/scala/Main.scala
@@ -12,8 +12,4 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.15.0"
-
-version in ThisBuild <<= (version in ThisBuild)(v => s"$v-SNAPSHOT") // We can't use LocalVersionPlugin here.
-
-licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+object Main {}

--- a/uniform-core/src/sbt-test/scala-settings/scala12/test
+++ b/uniform-core/src/sbt-test/scala-settings/scala12/test
@@ -1,0 +1,1 @@
+> compile

--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/ModuleIDOps.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/ModuleIDOps.scala
@@ -1,0 +1,16 @@
+package au.com.cba.omnia.uniform.dependency
+
+import sbt.ModuleID
+
+import au.com.cba.omnia.uniform.core.scala
+
+class ModuleIDOps(module: ModuleID) {
+  /**
+    * Exclude packages for all scala binary versions.
+    *
+    * Until we get a fix for https://github.com/sbt/sbt/issues/1518 it is really hard to do this
+    * properly so this takes a brute force approach and just excludes packages for each binary
+    * version. */
+  def scalaExcludeAll(group: String, artifact: String): ModuleID =
+    scala.allBinaryVersions.foldLeft(module)((m, v) => m.exclude(group, s"${artifact}_${v}"))
+}

--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
@@ -16,6 +16,7 @@ package au.com.cba.omnia.uniform.dependency
 
 import sbt._, Keys._
 
+import au.com.cba.omnia.uniform.core.scala
 import au.com.cba.omnia.uniform.core.scala.Scala
 
 object UniformDependencyPlugin extends Plugin {
@@ -191,6 +192,7 @@ object UniformDependencyPlugin extends Plugin {
         .map(m => ExclusionRule(m.organization, m.name))
   }
 
+  @deprecated("""Use exclude("org.mypkg", s"mypkg_${scalaBinaryVersion.value}") instead. This is hard coded to what ever version Scala.binaryVersion is currently""", "1.15.0")
   def sv(module: String): String = s"${module}_${Scala.binaryVersion}"
 
   object depend {
@@ -283,7 +285,7 @@ object UniformDependencyPlugin extends Plugin {
 
     def scalazStream(version: String = versions.scalazStream) = Seq(
       // Exclude scalaz since the versions are different
-      "org.scalaz.stream"        %% "scalaz-stream"                 % version exclude("org.scalaz", sv("scalaz-core")) exclude("org.scalaz", sv("scalaz-concurrent"))
+      "org.scalaz.stream"        %% "scalaz-stream"                 % version scalaExcludeAll("org.scalaz", "scalaz-core") scalaExcludeAll("org.scalaz", "scalaz-concurrent")
     )
 
     def shapeless(version: String = versions.shapeless) = Seq(
@@ -296,9 +298,9 @@ object UniformDependencyPlugin extends Plugin {
       configuration: String = "test"
     ) = Seq(
       "org.specs2"               %% "specs2-core"                   % specs       % configuration exclude("org.ow2.asm", "asm"),
-      "org.specs2"               %% "specs2-scalacheck"             % specs       % configuration exclude("org.ow2.asm", "asm") exclude("org.scalacheck", sv("scalacheck")),
-      "org.scalacheck"           %% "scalacheck"                    % scalacheck  % configuration exclude("org.scala-lang.modules", sv("scala-parser-combinators")),
-      "org.scalaz"               %% "scalaz-scalacheck-binding"     % scalaz      % configuration exclude("org.scalacheck", sv("scalacheck")),
+      "org.specs2"               %% "specs2-scalacheck"             % specs       % configuration exclude("org.ow2.asm", "asm") scalaExcludeAll("org.scalacheck", "scalacheck"),
+      "org.scalacheck"           %% "scalacheck"                    % scalacheck  % configuration scalaExcludeAll("org.scala-lang.modules", "scala-parser-combinators"),
+      "org.scalaz"               %% "scalaz-scalacheck-binding"     % scalaz      % configuration scalaExcludeAll("org.scalacheck", "scalacheck"),
       "asm"                      %  "asm"                           % asm         % configuration
     )
 
@@ -308,7 +310,7 @@ object UniformDependencyPlugin extends Plugin {
     )
 
     def scalding(scalding: String = versions.scalding, algebird: String = versions.algebird, bijection: String = versions.bijection) = Seq(
-      noHadoop("com.twitter"     %% "scalding-core"                 % scalding exclude("com.twitter", sv("bijection-core"))),
+      noHadoop("com.twitter"     %% "scalding-core"                 % scalding scalaExcludeAll("com.twitter", "bijection-core")),
       "com.twitter"              %% "algebird-core"                 % algebird,
       "com.twitter"              %% "bijection-core"                % bijection
     )
@@ -325,7 +327,7 @@ object UniformDependencyPlugin extends Plugin {
 
     def scrooge(scrooge: String = versions.scrooge, bijection: String = versions.bijection) = Seq(
       "com.twitter"              %% "scrooge-core"                  % scrooge,
-      "com.twitter"              %% "bijection-scrooge"             % bijection exclude("com.twitter", sv("scrooge-core"))
+      "com.twitter"              %% "bijection-scrooge"             % bijection scalaExcludeAll("com.twitter", "scrooge-core")
     ) map noHadoop
 
     def parquet(version: String = versions.parquet) = Seq(

--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/package.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/package.scala
@@ -14,6 +14,10 @@
 
 package au.com.cba.omnia.uniform
 
+import sbt.ModuleID
+
 package object dependency {
   type Sett = sbt.Def.Setting[_]
+
+  implicit def moduleIdDToModuleIDOps(m: ModuleID) = new ModuleIDOps(m)
 }


### PR DESCRIPTION
The default is still Scala 2.11.

Since I couldn't find a way to fix excluding Scala dependencies based on the scala version this uses a brute force approach and just excludes the artefacts for all possible Scala binary versions.

To use Scala 2.12 use `uniform.project12`. To fix to 2.11 use `uniform.project11`.