### PR TITLE
Update maven.twittr resolver to use HTTPS

### DIFF
--- a/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
+++ b/uniform-dependency/src/main/scala/au/com/cba/omnia/uniform/dependency/UniformDependencyPlugin.scala
@@ -28,7 +28,7 @@ object UniformDependencyPlugin extends Plugin {
     , "releases" at "http://oss.sonatype.org/content/repositories/releases"
     , "Concurrent Maven Repo" at "http://conjars.org/repo"
     , "Clojars Repository" at "http://clojars.org/repo"
-    , "Twitter Maven" at "http://maven.twttr.com"
+    , "Twitter Maven" at "https://maven.twttr.com"
     , "Hadoop Releases" at "https://repository.cloudera.com/content/repositories/releases/"
     , "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
     , "commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local"

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.16.0"
+version in ThisBuild := "1.16.1"
 
 version in ThisBuild <<= (version in ThisBuild)(v => s"$v-SNAPSHOT") // We can't use LocalVersionPlugin here.
 


### PR DESCRIPTION
The `maven.twttr.com` repo has changed to use HTTPS, so resolutions are failing.