### PR TITLE
Major version bump for CDH 5.13.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,4 +1,4 @@
-//   Copyright 2014 Commonwealth Bank of Australia
+//   Copyright 2014-2018 Commonwealth Bank of Australia
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.16.1"
+version in ThisBuild := "2.0.0"
 
 version in ThisBuild <<= (version in ThisBuild)(v => s"$v-SNAPSHOT") // We can't use LocalVersionPlugin here.
 


### PR DESCRIPTION
For reasons of practicality, I suggest we make the `cdh-513` branch have a major version number of 2.

I feel this will make things easier when keeping them in sync, since any sane git rebasing strategy will involve a linear history.

This natural ordering makes it clear that changes common to both branches should be made on `v1` branch, which `v2` is always kept rebased on top of.