### PR TITLE
v2.3.0 OCU-1294 Add shareSplitAssemblyPackageDependencyJar method

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,27 @@ Optional usage with `uniformAssemblySettings(splitPackageDeps = true)`:
 
 In this case, the `deps` jar can be passed to [Hadoop’s `-libjars`](https://hadoop.apache.org/docs/r2.6.0/hadoop-project-dist/hadoop-common/CommandsManual.html#Generic_Options) option to avoid unjarring the dependencies in a traditional fat assembly.
 
+### Sharing assemblyPackageDependency deps.jar between subprojects
+
+If you are using splitPackageDeps in a repo with many subprojects sharing the same libraryDependencies,
+you can re-use the deps.jar (instead of independently re-building it in each subproject).
+This can save time and disk usage during the builds.
+As of version 2.3.0 (December 2018), `uniform-assembly` supports a convenience method for this:
+
+`build.sbt`
+
+```
+...
+lazy val all = (project in file(".")).settings(
+  ...
+).aggregate(sub1, sub2)
+
+lazy val sub1 = project in file("sub1")
+
+lazy val sub2 = shareSplitAssemblyPackageDependencyJar(project in file("sub2"), sub1)
+...
+```
+
 docs
 ----
 

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.2.0"
+version in ThisBuild := "2.3.0"
 
 version in ThisBuild := s"${(version in ThisBuild).value}-SNAPSHOT" // We can't use LocalVersionPlugin here.
 


### PR DESCRIPTION
This allows significant build-time savings for repos that have many subprojects with the same libraryDependencies, as they can re-use a shared deps.jar assembly.